### PR TITLE
making mobile schedule better

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -57,7 +57,7 @@
                 </a>
             </div>
         </div>
-        <div class="row">
+        <div class="row hidden-xs">
             <div class="col-md-8">
                 <table class="table table-bordered text-center">
                     <tr class="bg-info">
@@ -106,6 +106,51 @@
                         <th colspan="2" class="text-center"><a href="./online-events">Live Stream</a></th>
                     </tr>
                 </table>
+            </div>
+            <div class="col-md-4">
+                @if ($sponsor = $conference->sponsors->filter(function ($sponsor) {return $sponsor->rank >= 1070;})->random(1))
+                    <p class="text-center">PNWPHP is sponsored in part by:</p>
+                    <a target="_blank" href="{{ $sponsor->url }}" title="{{ $sponsor->name }}">
+                        <img src="{{ $sponsor->logo }}" alt="{{ $sponsor->name }}" class="img-responsive center-block" />
+                    </a>
+                @endif
+            </div>
+        </div>
+        <div class="row visible-xs-block">
+            <div class="col-md-8">
+                <h3>EVENTS: </h3>
+                <hr>
+
+                <p><strong>WED, SEP 9TH</strong></p>
+                <ul>
+                    <li><a href="./events#seaphp-meetup">Meetup</a></li>
+                    <li><a href="./events#seaphp-drinkup">Drinkup</a></li>
+                </ul>
+                <p><strong>THU, SEP 10TH</strong></p>
+                <ul>
+                    <li><a href="./events#pnwphp-workshops">Workshops</a></li>
+                    <li><a href="./events-hackathon">Hackathon</a></li>
+                </ul>
+                <p><strong>FRI, SEP 11TH</strong></p>
+                <ul>
+                    <li><a href="./events#conference">Conference</a></li>
+                    <li><a href="./events#uncon">UnCon</a></li>
+                    <li><a href="./events#social">Social</a></li>
+                    <li><a href="./events#social">JeoPHPardy</a></li>
+                    <li><a href="./online-events">Live Stream</a></li>
+                </ul>
+                <p><strong>SAT, SEP 12TH</strong></p>
+                <ul>
+                    <li><a href="./events#pnwphp">Conference</a></li>
+                    <li><a href="./events#uncon">UnCon</a></li>
+                    <li>Prizes</li>
+                    <li><a href="./events#podcast-devhell">Podcasts</a></li>
+                    <li><a href="./online-events">Live Stream</a></li>
+                </ul>
+                <p><strong>SUN, SEP 13TH</strong></p>
+                <ul>
+                    <li><a href="./events#wurstcon">WurstConSEA</a></li>
+                </ul>
             </div>
             <div class="col-md-4">
                 @if ($sponsor = $conference->sponsors->filter(function ($sponsor) {return $sponsor->rank >= 1070;})->random(1))


### PR DESCRIPTION
Previously the schedule was so wide that it was messing up the whole page. This fixes it by hiding the TABLE element and showing a bunch of UL > LI elements instead

cc @jeremeamia 

This is how it looks like with the PR: 

![screen shot 2015-09-10 at 1 38 11 pm](https://cloud.githubusercontent.com/assets/585833/9800360/660270ea-57c1-11e5-89ce-e3b2eb635fb6.png)
